### PR TITLE
Add dependency to Common Lisp

### DIFF
--- a/tumblr-mode.el
+++ b/tumblr-mode.el
@@ -44,6 +44,7 @@
 
 ;;; Code:
 
+(require 'cl)
 (require 'url)
 (require 'xml)
 


### PR DESCRIPTION
It is needed for the following functions decf, caddar, caddr. closes #1
